### PR TITLE
Fix manifest method name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The api:
 ```js
 var mdm = require('mdmanifest')
 
-mdm.muxrpcManifest(exampleMd)
+mdm.manifest(exampleMd)
 /* => {
   ping: 'async',
   listen: 'source'


### PR DESCRIPTION
Readme mentioned `mdm.muxrpcManifest` but it should be `mdm.manifest`
